### PR TITLE
Only creates output dir if DEVELOPER_MODE enabled

### DIFF
--- a/sawmill/config.py
+++ b/sawmill/config.py
@@ -32,9 +32,11 @@ class Conf:
     # ---------------------------------------------------
     output_dir = 'sawmill/log_files/'
     file_name = 'timber.log'
-
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    
+    
+    if DEVELOPER_MODE:
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
 
     FILE = {
         'MSG_FMT': MsgFormat.SYSOUT,

--- a/sawmill/config.py
+++ b/sawmill/config.py
@@ -34,9 +34,8 @@ class Conf:
     file_name = 'timber.log'
     
     
-    if DEVELOPER_MODE:
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
+    if DEVELOPER_MODE and not os.path.exists(output_dir):
+        os.makedirs(output_dir)
 
     FILE = {
         'MSG_FMT': MsgFormat.SYSOUT,


### PR DESCRIPTION
Stops write operation to create output directory in cases where we are logging to stdout - avoids issues on R/O filesystems where directory creation is not possible.