### PR TITLE
Added a sysout log level override to env vars

### DIFF
--- a/sawmill/config.py
+++ b/sawmill/config.py
@@ -24,7 +24,7 @@ class Conf:
     # Default logging level of each output type
     # ---------------------------------------------------
     DEFAULT_FILE_LEVEL = logging.DEBUG
-    DEFAULT_SYSOUT_LEVEL = logging.INFO
+    DEFAULT_SYSOUT_LEVEL = getattr(logging, config('LOGGING_LEVEL', default='INFO').upper())
     DEFAULT_CONSOLE_LEVEL = logging.DEBUG
 
     # ---------------------------------------------------


### PR DESCRIPTION
AWS cloudwatch logs use sysout - so trying to get DEBUG logs in the ECS view is impossible with sawmill.

Adding this override so I can update marionette terraform vars to enable switching.